### PR TITLE
fix(app): DeleteDocument must not report success for a document it cannot find

### DIFF
--- a/integrationtest/document_delete_test.go
+++ b/integrationtest/document_delete_test.go
@@ -1,18 +1,43 @@
 package integrationtest
 
 import (
+	"fmt"
 	"testing"
 
+	sderrors "github.com/sdinsure/agent/pkg/errors"
 	"github.com/stretchr/testify/assert"
 
 	restcolopenapidocument "github.com/footprintai/restcol/api/go-openapiv2/client/document"
 	restcolopenapimodel "github.com/footprintai/restcol/api/go-openapiv2/models"
 )
 
+// assertNotFound asserts that a call was refused because the document is not
+// there, in the given (project, collection) scope.
+//
+// It checks the application error code carried in the message rather than the
+// HTTP status, and that is deliberate. Standalone restcol answers 500 for
+// *every* application error: this module pins a github.com/sdinsure/agent that
+// predates GRPCStatus() on *sderrors.Error, so NotFound degrades to Unknown on
+// the way out through the gateway. Consumers whose module graph selects a newer
+// sdinsure — grandturks does, via MVS — already get a correct 404 out of this
+// same handler.
+//
+// Asserting the application code therefore states the real contract, passes
+// today, and keeps passing once the dependency is bumped and the status becomes
+// 404. Asserting 500 would freeze the bug into the suite.
+func assertNotFound(t *testing.T, err error) {
+	t.Helper()
+	if !assert.Error(t, err) {
+		return
+	}
+	want := fmt.Sprintf("code(%d),", sderrors.CodeNotFound.Int())
+	assert.Contains(t, err.Error(), want,
+		"expected a NotFound application error, got: %v", err)
+}
+
 func TestDeleteDocument(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skip now")
-		return
+		t.Skip("requires a local postgres; skipping under -short")
 	}
 
 	suite := SetupTest(t)
@@ -22,7 +47,6 @@ func TestDeleteDocument(t *testing.T) {
 
 	client := suite.NewClient()
 
-	// Create a document to delete
 	createDocumentParam := &restcolopenapidocument.RestColServiceCreateDocument2Params{
 		Body: &restcolopenapimodel.RestColServiceCreateDocumentBody{
 			Data: []byte(`{"test": "document for deletion"}`),
@@ -35,7 +59,6 @@ func TestDeleteDocument(t *testing.T) {
 	assert.NotNil(t, createResp.Payload.Metadata)
 	documentId := createResp.Payload.Metadata.DocumentID
 
-	// Verify document exists by getting it
 	getDocumentParam := &restcolopenapidocument.RestColServiceGetDocumentParams{
 		CollectionID: cid,
 		DocumentID:   documentId,
@@ -45,7 +68,6 @@ func TestDeleteDocument(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, documentId, getResp.Payload.Metadata.DocumentID)
 
-	// Delete the document
 	deleteDocumentParam := &restcolopenapidocument.RestColServiceDeleteDocumentParams{
 		CollectionID: cid,
 		DocumentID:   documentId,
@@ -53,18 +75,17 @@ func TestDeleteDocument(t *testing.T) {
 	}
 	deleteResp, err := client.Document.RestColServiceDeleteDocument(deleteDocumentParam, noAuthInfo())
 	assert.NoError(t, err)
-	assert.NotNil(t, deleteResp.Payload) // Should return empty response
+	assert.NotNil(t, deleteResp.Payload)
 
-	// Verify document is deleted (should return empty response)
-	getResp2, err := client.Document.RestColServiceGetDocument(getDocumentParam, noAuthInfo())
-	assert.NoError(t, err) // GetDocument doesn't error for soft-deleted records
-	assert.Empty(t, getResp2.Payload.Metadata.DocumentID) // Should return empty metadata
+	// The whole point of the feature (grandturks#936): the document is gone, and
+	// the API says NotFound rather than answering 200 with blank metadata.
+	_, err = client.Document.RestColServiceGetDocument(getDocumentParam, noAuthInfo())
+	assertNotFound(t, err)
 }
 
 func TestDeleteDocument_NonExistent(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skip now")
-		return
+		t.Skip("requires a local postgres; skipping under -short")
 	}
 
 	suite := SetupTest(t)
@@ -74,21 +95,21 @@ func TestDeleteDocument_NonExistent(t *testing.T) {
 
 	client := suite.NewClient()
 
-	// Try to delete a non-existent document (should succeed due to idempotent behavior)
+	// Deleting something that was never there is a 404, not a silent success.
+	// A caller that gets 200 back has no way to distinguish "removed it" from
+	// "removed nothing", which is the failure mode this endpoint shipped with.
 	deleteDocumentParam := &restcolopenapidocument.RestColServiceDeleteDocumentParams{
 		CollectionID: cid,
 		DocumentID:   "non-existent-document-id",
 		ProjectID:    projectId,
 	}
-	deleteResp, err := client.Document.RestColServiceDeleteDocument(deleteDocumentParam, noAuthInfo())
-	assert.NoError(t, err) // DELETE is idempotent - should succeed even for non-existent documents
-	assert.NotNil(t, deleteResp.Payload) // Should return empty response
+	_, err := client.Document.RestColServiceDeleteDocument(deleteDocumentParam, noAuthInfo())
+	assertNotFound(t, err)
 }
 
 func TestDeleteDocument_InvalidParameters(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skip now")
-		return
+		t.Skip("requires a local postgres; skipping under -short")
 	}
 
 	suite := SetupTest(t)
@@ -98,29 +119,40 @@ func TestDeleteDocument_InvalidParameters(t *testing.T) {
 
 	client := suite.NewClient()
 
-	// Test with empty collection ID
+	// Empty collection id
 	deleteDocumentParam := &restcolopenapidocument.RestColServiceDeleteDocumentParams{
-		CollectionID: "", // Empty collection ID
+		CollectionID: "",
 		DocumentID:   "some-document-id",
 		ProjectID:    projectId,
 	}
 	_, err := client.Document.RestColServiceDeleteDocument(deleteDocumentParam, noAuthInfo())
-	assert.Error(t, err) // Should return validation error
+	assert.Error(t, err)
 
-	// Test with empty document ID
+	// Empty document id
 	deleteDocumentParam = &restcolopenapidocument.RestColServiceDeleteDocumentParams{
 		CollectionID: cid,
-		DocumentID:   "", // Empty document ID
+		DocumentID:   "",
 		ProjectID:    projectId,
 	}
 	_, err = client.Document.RestColServiceDeleteDocument(deleteDocumentParam, noAuthInfo())
-	assert.Error(t, err) // Should return validation error
+	assert.Error(t, err)
 }
 
-func TestDeleteDocument_CrossProject(t *testing.T) {
+// TestDeleteDocument_UnknownProjectIsRejected pins where tenancy is actually
+// decided, which is not where the handler code suggests.
+//
+// The handler never reads req.ProjectId; it calls getProjectIdFromCtx. What
+// fills that context is the project identity middleware, and *that* reads the
+// {projectId} path parameter and resolves it against the projects table. So the
+// path segment is load-bearing after all: an id that resolves to no project is
+// refused before the handler runs, with BadParameters rather than NotFound.
+//
+// Scoping between two *existing* projects cannot be exercised here — this suite
+// boots a single bootstrap tenant — and is covered at the handler level in
+// pkg/app/handlers_test.go, where the resolver can be varied.
+func TestDeleteDocument_UnknownProjectIsRejected(t *testing.T) {
 	if testing.Short() {
-		t.Skip("skip now")
-		return
+		t.Skip("requires a local postgres; skipping under -short")
 	}
 
 	suite := SetupTest(t)
@@ -130,34 +162,34 @@ func TestDeleteDocument_CrossProject(t *testing.T) {
 
 	client := suite.NewClient()
 
-	// Create a document
-	createDocumentParam := &restcolopenapidocument.RestColServiceCreateDocument2Params{
-		Body: &restcolopenapimodel.RestColServiceCreateDocumentBody{
-			Data: []byte(`{"test": "document for cross-project deletion test"}`),
-		},
-		CollectionID: cid,
-		ProjectID:    projectId,
-	}
-	createResp, err := client.Document.RestColServiceCreateDocument2(createDocumentParam, noAuthInfo())
+	createResp, err := client.Document.RestColServiceCreateDocument2(
+		&restcolopenapidocument.RestColServiceCreateDocument2Params{
+			Body: &restcolopenapimodel.RestColServiceCreateDocumentBody{
+				Data: []byte(`{"test": "path project id is ignored"}`),
+			},
+			CollectionID: cid,
+			ProjectID:    projectId,
+		}, noAuthInfo())
 	assert.NoError(t, err)
 	documentId := createResp.Payload.Metadata.DocumentID
 
-	// Try to delete with wrong project ID (should succeed but not affect the actual document)
-	deleteDocumentParam := &restcolopenapidocument.RestColServiceDeleteDocumentParams{
-		CollectionID: cid,
-		DocumentID:   documentId,
-		ProjectID:    "wrong-project-id", // Wrong project ID
-	}
-	_, err = client.Document.RestColServiceDeleteDocument(deleteDocumentParam, noAuthInfo())
-	assert.NoError(t, err) // DELETE succeeds (0 rows affected)
+	_, err = client.Document.RestColServiceDeleteDocument(
+		&restcolopenapidocument.RestColServiceDeleteDocumentParams{
+			CollectionID: cid,
+			DocumentID:   documentId,
+			ProjectID:    "wrong-project-id",
+		}, noAuthInfo())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), fmt.Sprintf("code(%d),", sderrors.CodeBadParameters.Int()),
+		"an unresolvable project must be rejected by the identity middleware, got: %v", err)
 
-	// Verify document still exists with correct project ID
-	getDocumentParam := &restcolopenapidocument.RestColServiceGetDocumentParams{
-		CollectionID: cid,
-		DocumentID:   documentId,
-		ProjectID:    projectId,
-	}
-	getResp, err := client.Document.RestColServiceGetDocument(getDocumentParam, noAuthInfo())
+	// ... and the document is untouched under its real project.
+	getResp, err := client.Document.RestColServiceGetDocument(
+		&restcolopenapidocument.RestColServiceGetDocumentParams{
+			CollectionID: cid,
+			DocumentID:   documentId,
+			ProjectID:    projectId,
+		}, noAuthInfo())
 	assert.NoError(t, err)
 	assert.Equal(t, documentId, getResp.Payload.Metadata.DocumentID)
 }

--- a/integrationtest/suite.go
+++ b/integrationtest/suite.go
@@ -2,6 +2,9 @@ package integrationtest
 
 import (
 	"fmt"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,6 +14,7 @@ import (
 
 	restcolgohttpclient "github.com/footprintai/restcol/api/go-http-client"
 	restcolopenapi "github.com/footprintai/restcol/api/go-openapiv2/client"
+	bootstrap "github.com/footprintai/restcol/pkg/bootstrap"
 	serverapp "github.com/footprintai/restcol/pkg/server/app"
 )
 
@@ -44,10 +48,48 @@ func SetupTest(t *testing.T) *suite {
 	fmt.Print("integrationtest about to start\n")
 	go svr.Start()
 
-	// wait for everything is ready
-	time.Sleep(1 * time.Second)
+	waitGatewayReady(t)
 
 	return &suite{
 		svr: svr,
 	}
+}
+
+// waitGatewayReady blocks until the HTTP gateway can actually reach the gRPC
+// server behind it.
+//
+// A fixed sleep is not enough, and not because the server is slow: the gateway
+// registers its client connection before the gRPC listener binds, so that
+// connection starts in failure and only recovers on gRPC's own reconnect
+// backoff. The listener is up in ~100ms but the gateway keeps answering 503
+// (code 14, "connection refused") for a second or more afterwards, which is
+// exactly where the old one-second sleep landed. Poll the real thing instead.
+func waitGatewayReady(t *testing.T) {
+	t.Helper()
+
+	const timeout = 30 * time.Second
+	probe := "http://localhost:50051/v1/projects/" + bootstrap.DefaultModelProject.ID.String() + "/collections"
+
+	deadline := time.Now().Add(timeout)
+	var last string
+	for time.Now().Before(deadline) {
+		resp, err := http.Get(probe)
+		if err != nil {
+			last = err.Error()
+			time.Sleep(50 * time.Millisecond)
+			continue
+		}
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		resp.Body.Close()
+
+		// Any answer that came from the application means the gateway reached
+		// gRPC. Only an unavailable-transport reply means it did not.
+		if !(resp.StatusCode == http.StatusServiceUnavailable &&
+			(strings.Contains(string(body), `"code":14`) || strings.Contains(string(body), "transport:"))) {
+			return
+		}
+		last = fmt.Sprintf("%d %s", resp.StatusCode, body)
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("gateway never reached the grpc server within %s; last response: %s", timeout, last)
 }

--- a/pkg/app/documents.go
+++ b/pkg/app/documents.go
@@ -14,9 +14,34 @@ import (
 	apppb "github.com/footprintai/restcol/api/pb"
 	collectionsmodel "github.com/footprintai/restcol/pkg/models/collections"
 	documentsmodel "github.com/footprintai/restcol/pkg/models/documents"
+	projectsmodel "github.com/footprintai/restcol/pkg/models/projects"
 	schemafinder "github.com/footprintai/restcol/pkg/schema"
 	documentsstorage "github.com/footprintai/restcol/pkg/storage/documents"
 )
+
+// loadDocumentInScope fetches a document and turns "no such row" into NotFound.
+//
+// It exists because DocumentCURD.Get is built on gorm's Find, which yields a
+// zero-valued record and a *nil* error when nothing matches. A caller that
+// checks only err therefore cannot tell a hit from a miss, and neither can it
+// tell a document in this (project, collection) from one in somebody else's.
+// Every read of a single document must go through here.
+func (r *RestColServiceServerService) loadDocumentInScope(
+	ctx context.Context,
+	pid projectsmodel.ProjectID,
+	cid collectionsmodel.CollectionID,
+	did documentsmodel.DocumentID,
+) (*documentsmodel.ModelDocument, error) {
+	docModel, err := r.documentCURD.Get(ctx, "", pid, cid, did)
+	if err != nil {
+		return nil, err
+	}
+	if docModel.ID.String() == "" {
+		return nil, sderrors.NewNotFoundError(
+			fmt.Errorf("document %s not found in collection %s", did.String(), cid.String()))
+	}
+	return docModel, nil
+}
 
 // CreateDocument writes a document, auto-detecting its schema against the
 // collection's latest known schema. When no collection is supplied, one is
@@ -109,15 +134,9 @@ func (r *RestColServiceServerService) GetDocument(ctx context.Context, req *appp
 	if err != nil {
 		return nil, sderrors.NewBadParamsError(fmt.Errorf("invalid document_id: %w", err))
 	}
-	docModel, err := r.documentCURD.Get(ctx, "", projectId, cid, did)
+	docModel, err := r.loadDocumentInScope(ctx, projectId, cid, did)
 	if err != nil {
 		return nil, err
-	}
-	// Storage .Get returns an empty record (no error) for soft-deleted or
-	// scope-mismatched rows. Convert that into NotFound so the handler cannot
-	// leak a blank response under the wrong project/collection.
-	if docModel.ID.String() == "" {
-		return nil, sderrors.NewNotFoundError(fmt.Errorf("document %s not found in collection %s", did.String(), cid.String()))
 	}
 	filteredDoc, err := r.filterDocWithSelectedFields(docModel, req.FieldSelectors)
 	if err != nil {
@@ -148,7 +167,10 @@ func (r *RestColServiceServerService) DeleteDocument(ctx context.Context, req *a
 		return nil, sderrors.NewBadParamsError(fmt.Errorf("invalid document_id: %w", err))
 	}
 
-	if _, err := r.documentCURD.Get(ctx, "", projectId, cid, did); err != nil {
+	// Not a redundant read: this is what makes the delete return NotFound
+	// instead of reporting success for a document that was never there, in
+	// another collection, or in another tenant's project.
+	if _, err := r.loadDocumentInScope(ctx, projectId, cid, did); err != nil {
 		return nil, err
 	}
 	if err := r.documentCURD.Delete(ctx, "", projectId, cid, did); err != nil {

--- a/pkg/app/handlers_test.go
+++ b/pkg/app/handlers_test.go
@@ -182,12 +182,17 @@ func TestGetDocument_ValidationAndScope(t *testing.T) {
 			code: sderrors.CodeBadParameters,
 		},
 		{
-			name: "malformed document id",
+			// Document ids are opaque strings, not UUIDs: documentsmodel.Parse
+			// accepts anything and CreateDocument will happily store a
+			// caller-supplied "not-a-valid-doc-id". Rejecting the same string on
+			// read would make a document that can be created but never fetched,
+			// so an unrecognised id is NotFound rather than BadParameters.
+			name: "unrecognised document id",
 			req: &apppb.GetDocumentRequest{
 				CollectionId: collectionsmodel.NewCollectionID().String(),
 				DocumentId:   "not-a-valid-doc-id",
 			},
-			code: sderrors.CodeBadParameters,
+			code: sderrors.CodeNotFound,
 		},
 	}
 	for _, tc := range cases {
@@ -253,11 +258,122 @@ func TestDeleteDocument_Validation(t *testing.T) {
 	})
 	assertErrorCode(t, err, sderrors.CodeBadParameters)
 
+	// See the note in TestGetDocument_ValidationAndScope: an id that does not
+	// resolve is NotFound, not BadParameters, because ids are opaque.
 	_, err = svc.DeleteDocument(ctx, &apppb.DeleteDocumentRequest{
 		CollectionId: collectionsmodel.NewCollectionID().String(),
 		DocumentId:   "not-a-valid-doc-id",
 	})
-	assertErrorCode(t, err, sderrors.CodeBadParameters)
+	assertErrorCode(t, err, sderrors.CodeNotFound)
+}
+
+// TestDeleteDocument_RemovesDocument is the regression bar for grandturks#936:
+// the document must actually be gone, and saying so twice must not report
+// success the second time.
+func TestDeleteDocument_RemovesDocument(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires a local postgres; skipping under -short")
+	}
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+
+	coll, err := svc.CreateCollection(ctx, &apppb.CreateCollectionRequest{Description: strPtr("delete-me")})
+	assert.NoError(t, err)
+	cid := coll.XMetadata.CollectionId
+
+	created, err := svc.CreateDocument(ctx, &apppb.CreateDocumentRequest{
+		CollectionId: cid,
+		Data:         []byte(`{"field":"value"}`),
+	})
+	assert.NoError(t, err)
+	did := created.XMetadata.DocumentId
+
+	_, err = svc.DeleteDocument(ctx, &apppb.DeleteDocumentRequest{CollectionId: cid, DocumentId: did})
+	assert.NoError(t, err)
+
+	// The delete is a gorm soft delete, so this also proves the read path's
+	// implicit "deleted_at IS NULL" filter is doing the work we rely on.
+	_, err = svc.GetDocument(ctx, &apppb.GetDocumentRequest{CollectionId: cid, DocumentId: did})
+	assertErrorCode(t, err, sderrors.CodeNotFound)
+
+	_, err = svc.DeleteDocument(ctx, &apppb.DeleteDocumentRequest{CollectionId: cid, DocumentId: did})
+	assertErrorCode(t, err, sderrors.CodeNotFound)
+}
+
+// TestDeleteDocument_DisappearsFromQuery pins the collection listing, which is
+// the surface most callers poll rather than fetching documents by id.
+func TestDeleteDocument_DisappearsFromQuery(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires a local postgres; skipping under -short")
+	}
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+
+	coll, err := svc.CreateCollection(ctx, &apppb.CreateCollectionRequest{Description: strPtr("query-after-delete")})
+	assert.NoError(t, err)
+	cid := coll.XMetadata.CollectionId
+
+	keep, err := svc.CreateDocument(ctx, &apppb.CreateDocumentRequest{
+		CollectionId: cid,
+		Data:         []byte(`{"keep":true}`),
+	})
+	assert.NoError(t, err)
+	drop, err := svc.CreateDocument(ctx, &apppb.CreateDocumentRequest{
+		CollectionId: cid,
+		Data:         []byte(`{"keep":false}`),
+	})
+	assert.NoError(t, err)
+
+	_, err = svc.DeleteDocument(ctx, &apppb.DeleteDocumentRequest{
+		CollectionId: cid,
+		DocumentId:   drop.XMetadata.DocumentId,
+	})
+	assert.NoError(t, err)
+
+	resp, err := svc.QueryDocument(ctx, &apppb.QueryDocumentRequest{CollectionId: cid})
+	assert.NoError(t, err)
+
+	var got []string
+	for _, doc := range resp.Docs {
+		got = append(got, doc.XMetadata.DocumentId)
+	}
+	assert.Equal(t, []string{keep.XMetadata.DocumentId}, got)
+}
+
+// TestDeleteDocument_WrongCollectionReturnsNotFound proves the delete is scoped
+// rather than keyed on the document id alone. Before the scope check this
+// returned success while deleting nothing.
+func TestDeleteDocument_WrongCollectionReturnsNotFound(t *testing.T) {
+	if testing.Short() {
+		t.Skip("requires a local postgres; skipping under -short")
+	}
+	svc, _ := newTestService(t)
+	ctx := context.Background()
+
+	coll, err := svc.CreateCollection(ctx, &apppb.CreateCollectionRequest{Description: strPtr("owner")})
+	assert.NoError(t, err)
+	cid := coll.XMetadata.CollectionId
+
+	other, err := svc.CreateCollection(ctx, &apppb.CreateCollectionRequest{Description: strPtr("bystander")})
+	assert.NoError(t, err)
+
+	created, err := svc.CreateDocument(ctx, &apppb.CreateDocumentRequest{
+		CollectionId: cid,
+		Data:         []byte(`{"field":"value"}`),
+	})
+	assert.NoError(t, err)
+	did := created.XMetadata.DocumentId
+
+	_, err = svc.DeleteDocument(ctx, &apppb.DeleteDocumentRequest{
+		CollectionId: other.XMetadata.CollectionId,
+		DocumentId:   did,
+	})
+	assertErrorCode(t, err, sderrors.CodeNotFound)
+
+	// ... and the document is untouched in its own collection.
+	got, err := svc.GetDocument(ctx, &apppb.GetDocumentRequest{CollectionId: cid, DocumentId: did})
+	assert.NoError(t, err)
+	assert.Equal(t, did, got.XMetadata.DocumentId)
 }
 
 func TestGetCollection_MissingIDRejected(t *testing.T) {


### PR DESCRIPTION
## What

`DeleteDocument` could never return `NotFound`. Its existence check was dead code:

```go
if _, err := r.documentCURD.Get(ctx, "", projectId, cid, did); err != nil {
    return nil, err
}
```

`DocumentCURD.Get` is built on gorm's `Find`, which returns a zero-valued record and a **nil** error when nothing matches. So deleting a document that never existed, one in another collection, or one in another tenant's project answered `200` having deleted nothing.

That is the worse half of [grandturks#936](https://github.com/FootprintAI/grandturks/issues/936): the endpoint moved from failing loudly (501) to succeeding quietly, and callers still cannot tell what happened. The handler's own doc comment already promised `NotFound`.

`GetDocument` has had the correct guard twenty lines above since 073e3a3e, so this shares it instead of copying it — `loadDocumentInScope` does the read and converts "no such row in this scope" into `NotFound`, and both handlers use it.

## The tests had never run

CI runs `go test ./... -short`, and every postgres-backed test in this repo is gated on `testing.Short()`. Against a real database, `pkg/app` and `integrationtest` were **both red on `main`** before this change:

| Test | On `main` | Why |
|---|---|---|
| `TestDeleteDocument_Validation` | expected `BadParameters`, got `nil` | the bug above |
| `TestGetDocument_ValidationAndScope/malformed document id` | expected `BadParameters`, got `NotFound` | the test was wrong, see below |
| all of `integrationtest` | connection refused | readiness, see below |

**Document ids are opaque, so an unrecognised id is `NotFound`, not `BadParameters`.** `documentsmodel.Parse` accepts any string (its `uuid.Parse` is commented out) and `CreateDocument` will happily store a caller-supplied `"not-a-valid-doc-id"`. Rejecting that same string on read would create a document that can be written but never fetched or deleted. The two affected expectations are corrected, with the reasoning in a comment.

**`integrationtest` readiness.** `SetupTest` waited with `time.Sleep(1 * time.Second)`. The gRPC listener binds in ~100ms, but the gateway registers its client connection *before* that and only recovers on gRPC's own reconnect backoff, so it keeps answering 503 (`code 14`, connection refused) for a second or more — exactly where the sleep landed. Every test in the package failed. Replaced with a poll of the real route.

## New coverage

In `pkg/app/handlers_test.go` (table/subtest style of the file, real postgres):

- `TestDeleteDocument_RemovesDocument` — create → delete → get is `NotFound` → second delete is `NotFound`. The regression bar for #936.
- `TestDeleteDocument_DisappearsFromQuery` — the soft-deleted row leaves `QueryDocument`, proving the implicit `deleted_at IS NULL` filter rather than assuming it.
- `TestDeleteDocument_WrongCollectionReturnsNotFound` — scoped, and the document survives in its own collection.

Verified test-first: with the `documents.go` change reverted, `TestDeleteDocument_Validation`, `TestDeleteDocument_RemovesDocument` and `TestDeleteDocument_WrongCollectionReturnsNotFound` all fail; with it, the package is green.

`TestDeleteDocument_CrossProject` was replaced by `TestDeleteDocument_UnknownProjectIsRejected`. The original asserted that a wrong `{projectId}` in the path silently succeeds and claimed that as isolation. It isn't: the project identity middleware resolves that path segment against the projects table and refuses an id that resolves to nothing, with `BadParameters`, before the handler runs. The new test states that, and points at the handler tests for scoping between existing tenants (this suite boots a single bootstrap tenant).

## One thing deliberately not fixed here

The new integration assertions check the **application** error code, not the HTTP status, because standalone restcol answers **500 for every application error**: this module pins a `github.com/sdinsure/agent` that predates `GRPCStatus()` on `*Error`, so `NotFound` degrades to `Unknown` on the way out. Consumers whose module graph selects a newer sdinsure — grandturks does, via MVS — already get a correct 404 out of this same handler.

Bumping it is a breaking migration (`ProjectInfor` gained `Visibility()`, `logger.NewLogger` gained an argument) and belongs in its own change. Asserting `500` here would have frozen the bug into the suite.

## Test results

`go test ./... -p 1` against a real postgres, before and after:

- **flipped to green:** `pkg/app`, `integrationtest`
- **unchanged, still red for unrelated pre-existing reasons:** `pkg/encoding`, `pkg/notation/dot`, `pkg/runtime/js`, `pkg/runtime/swagdef`, `pkg/schema`, `pkg/storage/documents` (timestamp precision in `TestDocument`), `pkg/swagger/collections`
- `go test ./... -short` (what CI runs) stays green.

Refs: FootprintAI/grandturks#936

🤖 Generated with [Claude Code](https://claude.com/claude-code)