### PR TITLE
ci: actually run the postgres-backed tests

### DIFF
--- a/.github/workflows/go-build.yaml
+++ b/.github/workflows/go-build.yaml
@@ -19,6 +19,32 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-22.04
+
+    # Every postgres-backed test in this repo is gated on testing.Short(), and
+    # this job used to pass -short - so the whole integrationtest package, every
+    # pkg/app handler test and all of pkg/storage had never once executed in CI.
+    # The suite was green because it did not run. Providing the database is what
+    # makes -short unnecessary; see the Test step below.
+    #
+    # Credentials and database name are what sdinsure's storage testutils
+    # defaults to (127.0.0.1:5432, postgres/password/unittest), so tests need no
+    # configuration. TZ matches run_postgres.sh.
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          TZ: gmt+8
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: password
+          POSTGRES_DB: unittest
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d unittest"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+
     steps:
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -40,12 +66,21 @@ jobs:
       - name: Build
         run: go build ./...
 
+      # No -short: the postgres service above is what the skipped tests were
+      # waiting for.
+      #
+      # -p 1 is required, not tuning. The packages share one database and
+      # truncate tables in their setup, so parallel package binaries delete each
+      # other's fixtures and fail in ways that look like flakes.
+      #
+      # integrationtest binds fixed ports 50050/50051, which is another reason
+      # nothing here may run concurrently.
       - name: Test
         id: test
         run: |
           export GOPATH=/home/runner/go
           export PATH=$PATH:/home/runner/go/bin
-          go test -race -v ./... -short -coverprofile=coverage.out
+          go test -race -v ./... -p 1 -timeout 15m -coverprofile=coverage.out
   generated:
     name: Generated code is in sync
     runs-on: ubuntu-22.04

--- a/pkg/app/handlers_test.go
+++ b/pkg/app/handlers_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"testing"
 
+	storagetestutils "github.com/footprintai/restcol/pkg/storage/testutil"
 	sderrors "github.com/sdinsure/agent/pkg/errors"
 	"github.com/sdinsure/agent/pkg/logger"
 	sdinsureruntime "github.com/sdinsure/agent/pkg/runtime"
-	storagetestutils "github.com/sdinsure/agent/pkg/storage/testutils"
 	"github.com/stretchr/testify/assert"
 
 	apppb "github.com/footprintai/restcol/api/pb"

--- a/pkg/storage/collections/collections_test.go
+++ b/pkg/storage/collections/collections_test.go
@@ -8,8 +8,8 @@ import (
 	appmodelcollections "github.com/footprintai/restcol/pkg/models/collections"
 	dotnotation "github.com/footprintai/restcol/pkg/notation/dot"
 	storageprojects "github.com/footprintai/restcol/pkg/storage/projects"
+	storagetestutils "github.com/footprintai/restcol/pkg/storage/testutil"
 	"github.com/sdinsure/agent/pkg/logger"
-	storagetestutils "github.com/sdinsure/agent/pkg/storage/testutils"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/storage/documents/documents_test.go
+++ b/pkg/storage/documents/documents_test.go
@@ -13,8 +13,8 @@ import (
 	appmodelprojects "github.com/footprintai/restcol/pkg/models/projects"
 	storagecollectionstestutils "github.com/footprintai/restcol/pkg/storage/collections"
 	storageprojects "github.com/footprintai/restcol/pkg/storage/projects"
+	storagetestutils "github.com/footprintai/restcol/pkg/storage/testutil"
 	"github.com/sdinsure/agent/pkg/logger"
-	storagetestutils "github.com/sdinsure/agent/pkg/storage/testutils"
 )
 
 func TestDocument(t *testing.T) {
@@ -218,7 +218,7 @@ func TestDocumentCURD_Delete(t *testing.T) {
 
 	// Verify document is soft deleted (should return empty record)
 	deletedDoc, err := docCURD.Get(context.Background(), "", regularProject.ID, collection.ID, testDoc.ID)
-	assert.NoError(t, err) // Get doesn't error, just returns empty record
+	assert.NoError(t, err)                  // Get doesn't error, just returns empty record
 	assert.Empty(t, deletedDoc.ID.String()) // ID should be empty for soft-deleted record
 
 	// Test delete non-existent document (should not error in GORM)
@@ -248,7 +248,7 @@ func TestDocumentCURD_Delete_WithWrongScope(t *testing.T) {
 	assert.NoError(t, err)
 	proxyCollection, err := storagecollectionstestutils.TestCollectionSuite(postgrescli, proxyProject)
 	assert.NoError(t, err)
-	
+
 	err = collectionsCURD.Write(context.Background(), "", regularCollection)
 	assert.Nil(t, err)
 	err = collectionsCURD.Write(context.Background(), "", proxyCollection)

--- a/pkg/storage/projects/projects_test.go
+++ b/pkg/storage/projects/projects_test.go
@@ -3,8 +3,8 @@ package storageprojects
 import (
 	"testing"
 
+	storagetestutils "github.com/footprintai/restcol/pkg/storage/testutil"
 	"github.com/sdinsure/agent/pkg/logger"
-	storagetestutils "github.com/sdinsure/agent/pkg/storage/testutils"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/storage/testutil/postgres.go
+++ b/pkg/storage/testutil/postgres.go
@@ -1,0 +1,43 @@
+// Package storagetestutil provides the postgres handle restcol's tests run
+// against.
+//
+// It wraps sdinsure's NewTestPostgresCli and adjusts one thing: gorm's clock.
+package storagetestutil
+
+import (
+	"time"
+
+	"github.com/sdinsure/agent/pkg/logger"
+	storagepostgres "github.com/sdinsure/agent/pkg/storage/postgres"
+	storagetestutils "github.com/sdinsure/agent/pkg/storage/testutils"
+)
+
+// NewTestPostgresCli returns a postgres handle whose gorm clock is truncated to
+// microseconds.
+//
+// gorm stamps CreatedAt/UpdatedAt from Go's clock, which carries nanoseconds.
+// Postgres timestamp columns store microseconds. Without this, the struct left
+// in memory after a write and the struct read back from the database differ in
+// the last three digits:
+//
+//	written:  2026-08-13 11:58:56.333178631
+//	read back: 2026-08-13 11:58:56.333178000
+//
+// Every whole-struct comparison then fails on a field the test never set, and
+// the failure looks like a storage bug rather than a clock-resolution
+// mismatch. Truncating here makes the in-memory value equal to the stored one
+// for every model carrying CreatedAt/UpdatedAt, rather than fixing one
+// assertion at a time.
+//
+// Tests that need the raw sdinsure handle can still call it directly; this is
+// the default for anything that compares records it wrote.
+func NewTestPostgresCli(log logger.Logger) (*storagepostgres.PostgresDb, error) {
+	db, err := storagetestutils.NewTestPostgresCli(log)
+	if err != nil {
+		return nil, err
+	}
+	db.GormDB().NowFunc = func() time.Time {
+		return time.Now().Truncate(time.Microsecond)
+	}
+	return db, nil
+}


### PR DESCRIPTION
Closes #128.

## The problem

CI ran `go test ./... -short`, and **every** postgres-backed test in this repo is gated on `testing.Short()`. So the entire `integrationtest` package, every `pkg/app` handler test, and all of `pkg/storage` had never once executed in CI. The suite was green because it did not run.

Not theoretical. #126 found, against a real database:

- two `pkg/app` tests already failing
- the **whole** `integrationtest` package failing at startup on connection refused

Both had been red for as long as they had existed, and CI reported success the entire time.

## The change

A postgres service on the existing `build` job, and `-short` dropped. Credentials match what sdinsure's storage testutils defaults to (`127.0.0.1:5432`, `postgres`/`password`/`unittest`), so the tests need no configuration.

Two flags are load-bearing rather than tuning, and the workflow says so inline:

| flag | why |
|---|---|
| `-p 1` | the packages share one database and truncate tables in setup, so parallel package binaries delete each other's fixtures. `integrationtest` also binds fixed ports 50050/50051 |
| `-timeout 15m` | `integrationtest` starts a server per test |

## The one real failure, fixed at the source

`pkg/storage/documents.TestDocument` compares a written record against the one read back. gorm stamps `CreatedAt` from Go's nanosecond clock; postgres stores microseconds:

```
written:   2026-08-13 11:58:56.333178631
read back: 2026-08-13 11:58:56.333178000
```

Deterministic, not flaky, and it fails on a field the test never set.

Fixed as a class rather than as an assertion: `pkg/storage/testutil` wraps sdinsure's constructor and truncates gorm's `NowFunc` to microseconds, so the in-memory value equals the stored one for **every** model carrying `CreatedAt`/`UpdatedAt`. The four packages that build a test client now use it. Loosening the assertion instead would have left the next whole-struct comparison to rediscover this.

## Verification

Locally against `postgres:16-alpine` with the default credentials:

- `pkg/storage/documents` — **ok** (including `TestDocument`, and `TestDocumentCURD_Delete` / `_WithWrongScope`, which had also never run in CI)
- `pkg/storage/collections`, `pkg/storage/projects`, `pkg/app` — **ok**
- `integrationtest` — **ok** (12.5s)
- every remaining package — **ok**

No test is now skipped for want of a database. This PR is its own first proof: the `Build` job here runs the full suite.

Refs: #126, #127, FootprintAI/grandturks#936

🤖 Generated with [Claude Code](https://claude.com/claude-code)